### PR TITLE
Add support for PHP ^8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 clover.xml
 composer.lock
+.phpunit.result.cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,3 +24,15 @@ unittest:7.3:
 unittest:7.4:
   image: php:7.4
   <<: *unittest
+
+unittest:8.0:
+  image: php:8.0
+  <<: *unittest
+
+unittest:8.1:
+  image: php:8.1
+  <<: *unittest
+
+unittest:8.2:
+  image: php:8.2
+  <<: *unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
+  - '8.1'
+  - '8.2'
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,14 @@
         }
     },
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.1.0 || ^8.0.0",
         "omnipay/common": "^3.0.1",
-        "ext-json": "*"
+        "ext-json": "*",
+        "symfony/http-client": "^7.0"
     },
     "require-dev": {
-        "omnipay/tests": "^3.1"
+        "omnipay/tests": "^3.1 || ^4.0",
+        "http-interop/http-factory-guzzle": "^1.2"
     },
     "scripts": {
         "test": "phpunit"
@@ -42,5 +44,10 @@
             "name": "Rory Scholman",
             "email": "rory.scholman@worldstream.nl"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    }
 }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -13,7 +13,7 @@ class GatewayTest extends GatewayTestCase
 {
     protected $gateway;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Message/FetchTransactionTest.php
+++ b/tests/Message/FetchTransactionTest.php
@@ -14,7 +14,7 @@ class FetchTransactionTest extends TestCase
      */
     private $request;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->request = new FetchTransactionRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setPaymentId(self::PAYMENT_ID);


### PR DESCRIPTION
Closes #1 

- Updated `composer.json` to support PHP `8.x.y` versions
- Updated tests to follow `setUp` method
- Updated `travis` & rest of files to load PHP `8.x.y` versions